### PR TITLE
Use base system's python-cryptography

### DIFF
--- a/centos-7/Dockerfile
+++ b/centos-7/Dockerfile
@@ -14,7 +14,7 @@ rm -f /lib/systemd/system/anaconda.target.wants/*;
 
 RUN yum makecache fast \
   && yum -y install deltarpm epel-release initscripts \
-  && yum -y update && yum -y install sudo which python-pip \
+  && yum -y update && yum -y install sudo which python-pip python-cryptography \
   && yum clean all
 
 RUN pip install ansible

--- a/centos-8/Dockerfile
+++ b/centos-8/Dockerfile
@@ -15,7 +15,7 @@ rm -f /lib/systemd/system/anaconda.target.wants/*;
 RUN yum -y install rpm centos-release \
   && yum -y update \
   && yum -y install epel-release initscripts sudo which hostname \
-    python3 python3-pip
+    python3 python3-pip python3-cryptography
 
 RUN pip3 install ansible
 

--- a/ubuntu-16.04/Dockerfile
+++ b/ubuntu-16.04/Dockerfile
@@ -4,7 +4,10 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends locales \
      python-software-properties \
      software-properties-common \
+     python-cryptography \
      python-setuptools \
+     python-openssl \
+     python-wheel \
      wget rsyslog systemd systemd-cron sudo iproute2 python-pip\
   && rm -Rf /var/lib/apt/lists/* \
   && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
@@ -15,7 +18,7 @@ RUN sed -i 's/^\($ModLoad imklog\)/#\1/' /etc/rsyslog.conf
 # Fix potential UTF-8 errors with ansible-test.
 RUN locale-gen en_US.UTF-8
 
-RUN pip install ansible pyopenssl
+RUN pip install ansible
 
 # Install Ansible inventory file.
 RUN mkdir -p /etc/ansible

--- a/ubuntu-18.04/Dockerfile
+++ b/ubuntu-18.04/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:18.04
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     apt-utils locales python3-setuptools python3-pip \
+    python3-cryptography \
     software-properties-common rsyslog systemd systemd-cron sudo iproute2 \
   && rm -Rf /var/lib/apt/lists/* \
   && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \

--- a/ubuntu-20.04/Dockerfile
+++ b/ubuntu-20.04/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update \
    locales \
    python3-setuptools \
    python3-pip \
+   python3-cryptography \
    software-properties-common \
    rsyslog systemd systemd-cron sudo iproute2 \
   && rm -Rf /var/lib/apt/lists/* \


### PR DESCRIPTION
Without this patch, ansible install through pip tries to install
cryptography (as dep), which will fail because no rust runtime is
installed on those containers.

This fixes it by ensuring cryptography is already installed in the
OS, so it doesn't need to be reinstalled through pip.
This will only last as long as the cryptography installed from the
OS is not too low for ansible requirements. When this will be
the case, we can still decide to use constraints, or install
rust.

Fixes: #1 
